### PR TITLE
Fix Dozzle service network configuration to use 'monitoring' instead …

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -143,7 +143,7 @@ services:
       - 8081:8080
     restart: unless-stopped
     networks:
-      - media_mediaserver
+      - monitoring
 
 secrets:
   users:


### PR DESCRIPTION
…of 'media_mediaserver'